### PR TITLE
Update dioxus to v0.6.3 and adjust related code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "hemi"
-version = "5.6.0"
+version = "6.3.0"
 edition = "2021"
 authors = ["kualta <contact@kualta.dev>"]
 
 [dependencies]
-dioxus = { version = "0.5.6", features = ["web", "html"] }
+dioxus = { version = "0.6.3", features = ["web", "html"] }
 dioxus-material-symbols = "0.4.3"
 getrandom = { version = "0.2.7", features = ["js"] }
 log = "0.4.17"
@@ -15,8 +15,8 @@ serde = "1.0.152"
 serde_json = "1.0.81"
 tailwindcss-to-rust-macros = "0.1.2"
 wasm-logger = "0.2.0"
-wasm-bindgen = "=0.2.95"
-wasm-bindgen-cli = "=0.2.95"
+wasm-bindgen = "=0.2.100"
+wasm-bindgen-cli = "=0.2.100"
 web-sys = { version = "0.3.60", features = ["HtmlAudioElement"] }
 
 [profile.dev]
@@ -25,6 +25,16 @@ opt-level = 1
 [profile.release]
 opt-level = 2
 lto = true
+
+[profile.wasm-dev]
+inherits = "dev"
+opt-level = 1
+
+[profile.server-dev]
+inherits = "dev"
+
+[profile.android-dev]
+inherits = "dev"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,10 +92,10 @@ fn App() -> Element {
     use_context_provider(|| Signal::new(Layouts::default()));
     let mut layouts_state = use_context::<Signal<Layouts>>();
 
-    let layouts = use_resource(|| async move { Layouts::pull().await });
-    let mut init = use_signal(|| false);
-    if let Some(ref data) = *layouts.read() {
-        if !*init.read() {
+    let mut layouts = use_resource(|| async move { Layouts::pull().await });
+    
+    use_effect(move|| {
+        if let Some(ref data) = *layouts.read() {
             let mut app = app.write();
             *layouts_state.write() = data.clone();
 
@@ -112,11 +112,9 @@ fn App() -> Element {
                 TypingSide::Right => &dictionary.read().right,
             };
             app.typer = TypingData::new(10, current_dict);
-
-            init.set(true);
         }
-    }
-
+    });
+    
     let on_key_down = move |event: Event<KeyboardData>| {
         let key_code = event.code();
 


### PR DESCRIPTION
Hello!
I updated to dioxus v0.6.3!
It worked fine, but I fixed warning '1' that appeared.
Also, regarding the style link in index.html, `href=“./assets/tailwind.css”` is correct in the local environment, but is it different in the prod environment?
Please use whichever is necessary.


warning'1':
 %cWARN%c /src/warnings.rs:62%c Write on signal at src/main.rs:99:31 happened while a component was running. Writing to signals during a render can cause infinite rerenders when you read the same signal in the component. Consider writing to the signal in an effect, future, or event handler if possible.